### PR TITLE
Update MinGW to 7.0.0 on 19.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.mingw-w64.yml
+++ b/org.freedesktop.Sdk.Extension.mingw-w64.yml
@@ -64,8 +64,8 @@ modules:
     subdir: mingw-w64-headers
     sources: &mingw_src
       - type: archive
-        url: "https://downloads.sourceforge.net/mingw-w64/mingw-w64-v6.0.0.tar.bz2"
-        sha256: 805e11101e26d7897fce7d49cbb140d7bac15f3e085a91e0001e80b2adaf48f0
+        url: "https://downloads.sourceforge.net/mingw-w64/mingw-w64-v7.0.0.tar.bz2"
+        sha256: aa20dfff3596f08a7f427aab74315a6cb80c2b086b4a107ed35af02f9496b628
 
   - name: mingw-w32-headers
     build-options:

--- a/org.freedesktop.Sdk.Extension.mingw-w64.yml
+++ b/org.freedesktop.Sdk.Extension.mingw-w64.yml
@@ -25,7 +25,7 @@ modules:
 
   # Binutils
 
-  - name: binutils-mingw-w64
+  - name: binutils-x86_64
     build-options:
       config-opts:
         - --target=x86_64-w64-mingw32
@@ -42,7 +42,7 @@ modules:
         url: "https://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.gz"
         sha256: 9b0d97b3d30df184d302bced12f976aa1e5fbf4b0be696cdebc6cca30411a46e
 
-  - name: binutils-mingw-w32
+  - name: binutils-i686
     build-options:
       config-opts:
         - --target=i686-w64-mingw32
@@ -52,7 +52,7 @@ modules:
 
   # Headers
 
-  - name: mingw-w64-headers
+  - name: mingw-w64-headers-x86_64
     build-options:
       config-opts:
         - --target=x86_64-w64-mingw32
@@ -67,7 +67,7 @@ modules:
         url: "https://downloads.sourceforge.net/mingw-w64/mingw-w64-v7.0.0.tar.bz2"
         sha256: aa20dfff3596f08a7f427aab74315a6cb80c2b086b4a107ed35af02f9496b628
 
-  - name: mingw-w32-headers
+  - name: mingw-w64-headers-i686
     build-options:
       config-opts:
         - --target=i686-w64-mingw32
@@ -100,7 +100,7 @@ modules:
 
   # GCC bootstrap
 
-  - name: mingw-w64-gcc-bootstrap
+  - name: gcc-bootstrap-x86_64
     build-options:
       config-opts:
         - --target=x86_64-w64-mingw32
@@ -119,7 +119,7 @@ modules:
         url: "https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
         sha256: ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
 
-  - name: mingw-w32-gcc-bootstrap
+  - name: gcc-bootstrap-i686
     build-options:
       config-opts:
         - --target=i686-w64-mingw32
@@ -132,7 +132,7 @@ modules:
 
   # MinGW CRT
 
-  - name: mingw-w64-crt
+  - name: mingw-w64-crt-x86_64
     build-options:
       config-opts:
         - --host=x86_64-w64-mingw32
@@ -143,7 +143,7 @@ modules:
     subdir: mingw-w64-crt
     sources: *mingw_src
 
-  - name: mingw-w32-crt
+  - name: mingw-w64-crt-i686
     build-options:
       config-opts:
         - --host=i686-w64-mingw32
@@ -155,7 +155,7 @@ modules:
 
   # MinGW winpthreads
 
-  - name: mingw-w64-winpthreads
+  - name: mingw-w64-winpthreads-x86_64
     build-options:
       config-opts:
         - --host=x86_64-w64-mingw32
@@ -167,7 +167,7 @@ modules:
     subdir: mingw-w64-libraries/winpthreads
     sources: *mingw_src
 
-  - name: mingw-w32-winpthreads
+  - name: mingw-w64-winpthreads-i686
     build-options:
       config-opts:
         - --host=i686-w64-mingw32
@@ -179,7 +179,7 @@ modules:
 
   # GCC full
 
-  - name: mingw-w64-gcc
+  - name: gcc-x86_64
     build-options:
       config-opts:
         - --target=x86_64-w64-mingw32
@@ -199,7 +199,7 @@ modules:
     builddir: true
     sources: *gcc_sources
 
-  - name: mingw-w32-gcc
+  - name: gcc-i686
     build-options:
       config-opts:
         - --target=i686-w64-mingw32


### PR DESCRIPTION
Everything links with MinGW CRT statically, so updating MinGW shouldn't affect existing builds. New builds may break, however.