### PR TITLE
Switch to dwarf-2 exceptions

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.mingw-w64.yml
+++ b/org.freedesktop.Sdk.Extension.mingw-w64.yml
@@ -112,6 +112,8 @@ modules:
       - --enable-lto
       - --with-system-zlib
       - --enable-static
+      - --disable-sjlj-exceptions
+      - --with-dwarf2
     make-args:
       - all-gcc
     install-rule: install-gcc
@@ -196,6 +198,8 @@ modules:
       - --enable-libstdcxx-time=yes
       - --enable-libstdcxx-filesystem-ts=yes
       - --enable-libgomp
+      - --disable-sjlj-exceptions
+      - --with-dwarf2
     ensure-writable:
       - /lib/gcc/*/*/install-tools/*.conf
     install-rule: install-strip


### PR DESCRIPTION
dwarf-2 used to be broken in MinGW, however, now it seems to work fine, e.g. Fedora [switched](https://fedoraproject.org/wiki/Changes/Mingw32GccDwarf2) to it.
This removes ~10% runtime performance overhead in DXVK.